### PR TITLE
Add forms pages and footer links

### DIFF
--- a/app/components/PersonalLandingPage.tsx
+++ b/app/components/PersonalLandingPage.tsx
@@ -18,6 +18,7 @@ import clsx from 'clsx'; // Import clsx for conditional classes
 import { GlowingEffect } from '@/app/components/ui/glowing-effect';
 import { SplashCursor } from '@/app/components/ui/splash-cursor';
 import { motion } from 'framer-motion'; // Import motion
+import Link from 'next/link'
 
 // Helper component for icon links
 const IconLink = ({ href, Icon, label }: { href: string; Icon: React.ElementType; label: string }) => (
@@ -539,6 +540,12 @@ const PersonalLandingPage: React.FC = () => {
                 <IconLink href="https://dangerdano.itch.io/" Icon={Gamepad2} label="itch.io" />
                 <IconLink href="https://yourindie.dev" Icon={Globe} label="YourIndie.dev" />
                 <IconLink href="https://aicompaniontoolkit.com" Icon={Cpu} label="AI Toolkit" />
+             </div>
+             <div className="flex justify-center flex-wrap gap-x-6 gap-y-4 mt-4 text-accent/50">
+                <Link href="/contact" className="hover:text-accent">Contact Us</Link>
+                <Link href="/customer-feedback" className="hover:text-accent">Customer Feedback</Link>
+                <Link href="/newsletter-signup" className="hover:text-accent">Newsletter Sign Up</Link>
+                <Link href="/hire-me" className="hover:text-accent">Hire Me</Link>
              </div>
              <p className="mt-8 text-sm text-muted-foreground">&copy; {new Date().getFullYear()} Dane Willacker. All rights reserved.</p>
          </footer>

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,0 +1,17 @@
+import { type FC } from 'react'
+
+const ContactPage: FC = () => {
+  return (
+    <div className="w-screen min-h-screen p-4">
+      <iframe
+        src="https://www.improvforms.com/forms/chat/761e910f-297c-4d28-b67f-de3e048ca8a6"
+        width="100%"
+        height="600"
+        style={{ border: 'none' }}
+        title="Improv Forms"
+      />
+    </div>
+  )
+}
+
+export default ContactPage

--- a/app/customer-feedback/page.tsx
+++ b/app/customer-feedback/page.tsx
@@ -1,0 +1,17 @@
+import { type FC } from 'react'
+
+const CustomerFeedbackPage: FC = () => {
+  return (
+    <div className="w-screen min-h-screen p-4">
+      <iframe
+        src="https://www.improvforms.com/forms/chat/10380385-5903-4fcf-a5d3-362b3a606c97"
+        width="100%"
+        height="600"
+        style={{ border: 'none' }}
+        title="Improv Forms"
+      />
+    </div>
+  )
+}
+
+export default CustomerFeedbackPage

--- a/app/hire-me/page.tsx
+++ b/app/hire-me/page.tsx
@@ -1,0 +1,17 @@
+import { type FC } from 'react'
+
+const HireMePage: FC = () => {
+  return (
+    <div className="w-screen min-h-screen p-4">
+      <iframe
+        src="https://www.improvforms.com/forms/chat/f2f88d5d-f411-46b4-a137-46e511703d15"
+        width="100%"
+        height="600"
+        style={{ border: 'none' }}
+        title="Improv Forms"
+      />
+    </div>
+  )
+}
+
+export default HireMePage

--- a/app/newsletter-signup/page.tsx
+++ b/app/newsletter-signup/page.tsx
@@ -1,0 +1,17 @@
+import { type FC } from 'react'
+
+const NewsletterSignupPage: FC = () => {
+  return (
+    <div className="w-screen min-h-screen p-4">
+      <iframe
+        src="https://www.improvforms.com/forms/chat/6843ac88-ca17-4318-b116-4d00149b9ad4"
+        width="100%"
+        height="600"
+        style={{ border: 'none' }}
+        title="Improv Forms"
+      />
+    </div>
+  )
+}
+
+export default NewsletterSignupPage


### PR DESCRIPTION
## Summary
- embed Improv Forms on new pages for contact, feedback, newsletter signup and hiring
- link to the new form pages from the site footer

## Testing
- `npm run lint` *(fails: `next` not found)*