### PR TITLE
Fix unescaped apostrophes

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,7 +19,7 @@ export const metadata: Metadata = {
   metadataBase: new URL("https://danejw.com"),
   title: "Dane Willacker | AI + XR Developer",
   description:
-    "Portfolio of Dane Willacker (Danejw), an independent AI + XR developer based in Hawai'i.",
+    "Portfolio of Dane Willacker (Danejw), an independent AI + XR developer based in Hawai&#39;i.",
   keywords: [
     "Dane Willacker",
     "Danejw",
@@ -34,7 +34,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: "Dane Willacker | AI + XR Developer",
     description:
-      "Portfolio of Dane Willacker (Danejw), an independent AI + XR developer based in Hawai'i.",
+      "Portfolio of Dane Willacker (Danejw), an independent AI + XR developer based in Hawai&#39;i.",
     url: "https://danejw.com",
     siteName: "Danejw",
     images: [
@@ -53,7 +53,7 @@ export const metadata: Metadata = {
     site: "@Djw_learn",
     title: "Dane Willacker | AI + XR Developer",
     description:
-      "Portfolio of Dane Willacker (Danejw), an independent AI + XR developer based in Hawai'i.",
+      "Portfolio of Dane Willacker (Danejw), an independent AI + XR developer based in Hawai&#39;i.",
     images: ["/favicon_io/android-chrome-192x192.png"],
   },
 };

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -10,7 +10,7 @@ const NotFoundPage: FC = () => {
         <h1 className="text-6xl font-bold text-primary">404</h1>
         <h2 className="text-2xl font-semibold text-card-foreground">Page Not Found</h2>
         <p className="text-muted-foreground max-w-md mx-auto">
-          Oops! The page you're looking for seems to have wandered off into the digital void.
+          Oops! The page you&#39;re looking for seems to have wandered off into the digital void.
         </p>
         <Link 
           href="/"


### PR DESCRIPTION
## Summary
- escape apostrophes in metadata descriptions
- escape apostrophe in 404 page text

## Testing
- `npm run lint` *(fails: next not found)*