### PR TITLE
Add services page

### DIFF
--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -1,0 +1,37 @@
+import { type FC } from 'react'
+import Link from 'next/link'
+import { Twitter } from 'lucide-react'
+import { Linkedin, Github, Youtube, Gamepad2, Globe, Cpu } from 'lucide-react'
+
+const IconLink = ({ href, Icon, label }: { href: string; Icon: React.ElementType; label: string }) => (
+    <Link href={href} className="hover:text-accent">
+        <Icon className="w-6 h-6" />
+        <span className="sr-only">{label}</span>
+    </Link>
+);
+
+
+export const Footer: FC = () => {
+  return (
+    <footer className = "mt-16 border-t border-border pt-8 text-center" >
+        <p className="text-muted-foreground mb-6">Connect with me:</p>
+         <div className="flex justify-center flex-wrap gap-x-6 gap-y-4">
+            <IconLink href="https://www.linkedin.com/in/danejw" Icon={Linkedin} label="LinkedIn" />
+            <IconLink href="https://github.com/Danejw" Icon={Github} label="GitHub" />
+            <IconLink href="https://twitter.com/Djw_learn" Icon={Twitter} label="X" />
+            <IconLink href="https://www.youtube.com/channel/UCYnBPlKf3iqmaLcBC8maYYw" Icon={Youtube} label="YouTube" />
+            <IconLink href="https://dangerdano.itch.io/" Icon={Gamepad2} label="itch.io" />
+            <IconLink href="https://yourindie.dev" Icon={Globe} label="YourIndie.dev" />
+            <IconLink href="https://aicompaniontoolkit.com" Icon={Cpu} label="AI Toolkit" />
+         </div>
+         <div className="flex justify-center flex-wrap gap-x-6 gap-y-4 mt-4 text-accent/50">
+            <Link href="/contact" className="hover:text-accent">Contact Us</Link>
+            <Link href="/customer-feedback" className="hover:text-accent">Customer Feedback</Link>
+            <Link href="/newsletter-signup" className="hover:text-accent">Newsletter Sign Up</Link>
+            <Link href="/services" className="hover:text-accent">Services</Link>
+            <Link href="/hire-me" className="hover:text-accent">Hire Me</Link>
+        </div>
+         <p className="mt-8 text-sm text-muted-foreground">&copy; {new Date().getFullYear()} Dane Willacker. All rights reserved.</p>
+    </footer >
+  )
+} 

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import { type FC, useState } from 'react'
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { cn } from '@/lib/utils'
+import { Menu, X } from 'lucide-react'
+
+const navigation = [
+  { name: 'About', href: '/about' },
+  { name: 'Services', href: '/services' },
+  { name: 'Contact', href: '/contact' },
+]
+
+export const Header: FC = () => {
+  const pathname = usePathname()
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
+
+  return (
+    <header className="relative z-20 border-b border-border/40 bg-background/80 backdrop-blur-sm">
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex justify-between items-center h-16">
+          {/* Logo */}
+          <Link href="/" className="flex items-center space-x-2 group">
+            <div className="w-12 h-10 bg-primary rounded-lg flex items-center justify-center group-hover:bg-accent transition-colors">
+              <span className="text-primary-foreground font-bold text-lg group-hover:text-accent-foreground transition-colors">DW</span>
+            </div>
+          </Link>
+
+          {/* Desktop Navigation */}
+          <nav className="hidden md:flex space-x-8">
+            {navigation.map((item) => (
+              <Link
+                key={item.name}
+                href={item.href}
+                className={cn(
+                  'text-sm font-medium transition-colors hover:text-accent relative',
+                  'after:absolute after:bottom-0 after:left-0 after:h-0.5 after:w-0 after:bg-accent after:transition-all after:duration-300',
+                  'hover:after:w-full',
+                  pathname === item.href
+                    ? 'text-primary after:w-full after:bg-primary'
+                    : 'text-muted-foreground'
+                )}
+              >
+                {item.name}
+              </Link>
+            ))}
+          </nav>
+
+          {/* Mobile menu button */}
+          <div className="md:hidden">
+            <button 
+              onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
+              className="p-2 rounded-lg text-muted-foreground hover:text-accent hover:bg-muted/50 transition-all duration-200 border border-transparent hover:border-border/40"
+            >
+              {mobileMenuOpen ? (
+                <X className="w-6 h-6" />
+              ) : (
+                <Menu className="w-6 h-6" />
+              )}
+            </button>
+          </div>
+        </div>
+
+        {/* Mobile Navigation */}
+        {mobileMenuOpen && (
+          <div className="md:hidden border-t border-border/40 bg-background/95 backdrop-blur-sm">
+            <nav className="py-4 space-y-2">
+              {navigation.map((item) => (
+                <Link
+                  key={item.name}
+                  href={item.href}
+                  onClick={() => setMobileMenuOpen(false)}
+                  className={cn(
+                    'block px-4 py-2 text-sm font-medium transition-all duration-200 rounded-lg mx-2',
+                    'hover:bg-muted/50 hover:text-accent',
+                    pathname === item.href
+                      ? 'text-primary bg-primary/10 border-l-2 border-primary'
+                      : 'text-muted-foreground'
+                  )}
+                >
+                  {item.name}
+                </Link>
+              ))}
+            </nav>
+          </div>
+        )}
+      </div>
+    </header>
+  )
+} 

--- a/app/components/PersonalLandingPage.tsx
+++ b/app/components/PersonalLandingPage.tsx
@@ -6,7 +6,6 @@ import {
   Linkedin,
   Twitter, // Represents X
   Youtube,
-  Globe, // For websites
   ExternalLink,
   Code, // Represents Web/Software Engineering & Tools
   Cpu, // Using Cpu for AI Integration, replacing Brain
@@ -18,7 +17,7 @@ import clsx from 'clsx'; // Import clsx for conditional classes
 import { GlowingEffect } from '@/app/components/ui/glowing-effect';
 import { SplashCursor } from '@/app/components/ui/splash-cursor';
 import { motion } from 'framer-motion'; // Import motion
-import Link from 'next/link'
+
 
 // Helper component for icon links
 const IconLink = ({ href, Icon, label }: { href: string; Icon: React.ElementType; label: string }) => (

--- a/app/components/PersonalLandingPage.tsx
+++ b/app/components/PersonalLandingPage.tsx
@@ -529,28 +529,6 @@ const PersonalLandingPage: React.FC = () => {
            </div>
         </motion.section>
 
-         {/* Footer - Updated Links */}
-         <footer className="mt-16 border-t border-border pt-8 text-center">
-            <p className="text-muted-foreground mb-6">Connect with me:</p>
-             <div className="flex justify-center flex-wrap gap-x-6 gap-y-4">
-                <IconLink href="https://www.linkedin.com/in/danejw" Icon={Linkedin} label="LinkedIn" />
-                <IconLink href="https://github.com/Danejw" Icon={Github} label="GitHub" />
-                <IconLink href="https://twitter.com/Djw_learn" Icon={Twitter} label="X" />
-                <IconLink href="https://www.youtube.com/channel/UCYnBPlKf3iqmaLcBC8maYYw" Icon={Youtube} label="YouTube" />
-                <IconLink href="https://dangerdano.itch.io/" Icon={Gamepad2} label="itch.io" />
-                <IconLink href="https://yourindie.dev" Icon={Globe} label="YourIndie.dev" />
-                <IconLink href="https://aicompaniontoolkit.com" Icon={Cpu} label="AI Toolkit" />
-             </div>
-             <div className="flex justify-center flex-wrap gap-x-6 gap-y-4 mt-4 text-accent/50">
-                <Link href="/contact" className="hover:text-accent">Contact Us</Link>
-                <Link href="/customer-feedback" className="hover:text-accent">Customer Feedback</Link>
-                <Link href="/newsletter-signup" className="hover:text-accent">Newsletter Sign Up</Link>
-                <Link href="/services" className="hover:text-accent">Services</Link>
-                <Link href="/hire-me" className="hover:text-accent">Hire Me</Link>
-            </div>
-             <p className="mt-8 text-sm text-muted-foreground">&copy; {new Date().getFullYear()} Dane Willacker. All rights reserved.</p>
-         </footer>
-
       </div>
     </div>
   );

--- a/app/components/PersonalLandingPage.tsx
+++ b/app/components/PersonalLandingPage.tsx
@@ -545,8 +545,9 @@ const PersonalLandingPage: React.FC = () => {
                 <Link href="/contact" className="hover:text-accent">Contact Us</Link>
                 <Link href="/customer-feedback" className="hover:text-accent">Customer Feedback</Link>
                 <Link href="/newsletter-signup" className="hover:text-accent">Newsletter Sign Up</Link>
+                <Link href="/services" className="hover:text-accent">Services</Link>
                 <Link href="/hire-me" className="hover:text-accent">Hire Me</Link>
-             </div>
+            </div>
              <p className="mt-8 text-sm text-muted-foreground">&copy; {new Date().getFullYear()} Dane Willacker. All rights reserved.</p>
          </footer>
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,8 @@ import "./globals.css";
 import { ThemeProvider } from "@/app/components/ThemeProvider";
 import { cn } from '@/lib/utils';
 import { ThemeAwareCircuitBackground } from '@/app/components/ThemeAwareCircuitBackground';
+import { Header } from '@/app/components/Header';
+import { Footer } from '@/app/components/Footer';
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -67,7 +69,7 @@ export default function RootLayout({
     <html lang="en" className="dark" suppressHydrationWarning>
       <body
         className={cn(
-          'min-h-screen bg-background font-sans antialiased relative',
+          'min-h-screen bg-background font-sans antialiased relative flex flex-col',
           geistSans.variable,
           geistMono.variable
         )}
@@ -75,7 +77,9 @@ export default function RootLayout({
         <ThemeAwareCircuitBackground />
 
         <ThemeProvider attribute="class" defaultTheme="dark" enableSystem={false} disableTransitionOnChange>
-          <main className="relative z-10">{children}</main>
+          <Header />
+          <main className="relative z-10 flex-1">{children}</main>
+          <Footer />
         </ThemeProvider>
       </body>
     </html>

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -3,46 +3,48 @@ import { type FC } from 'react'
 const ServicesPage: FC = () => {
   return (
     <div className="max-w-3xl mx-auto px-4 py-12 space-y-8">
-      <h1 className="text-3xl sm:text-4xl font-bold text-center text-primary">Instant Access to Your Company&#39;s Knowledge</h1>
-      <p className="text-muted-foreground text-center">
-        I build AI agents that turn your business documents into an always-on knowledge base.
+      <h1 className="text-3xl sm:text-4xl font-bold text-center text-primary">Transform Your Business Documents Into an AI-Powered Knowledge Base</h1>
+      <p className="text-muted-foreground text-center text-lg">
+        Stop wasting time searching for information. I build custom AI agents that give your team instant access to your company's knowledge.
       </p>
 
-      <h2 className="text-2xl font-semibold mt-8">The Problem</h2>
+      <h2 className="text-2xl font-semibold mt-8">The Challenge Your Business Faces</h2>
       <p>
-        Most companies store thousands of files in Google Drive. Employees waste hours searching for information that already exists.
+        Your company has thousands of valuable documents scattered across Google Drive, SharePoint, and other platforms. Your employees spend hours every week searching for information that already exists, leading to decreased productivity and frustration.
       </p>
 
-      <h2 className="text-2xl font-semibold mt-8">My Solution</h2>
+      <h2 className="text-2xl font-semibold mt-8">AI Knowledge Base Solution</h2>
       <ul className="list-disc pl-6 space-y-2">
-        <li>Automatically fetches new documents from Google Drive</li>
-        <li>Extracts key data from PDFs, images and more using AI</li>
-        <li>Creates a searchable knowledge base with vector embeddings</li>
-        <li>Deploys a chat agent that answers questions instantly</li>
+        <li>Automatically connects to your existing document storage systems</li>
+        <li>Uses advanced AI to extract and understand content from PDFs, images, and documents</li>
+        <li>Creates an intelligent, searchable knowledge base</li>
+        <li>Provides a conversational AI assistant that answers questions instantly</li>
+        <li>Updates automatically as you add new documents</li>
       </ul>
 
-      <h2 className="text-2xl font-semibold mt-8">Real Results</h2>
+      <h2 className="text-2xl font-semibold mt-8">Proven Business Impact</h2>
       <ul className="list-disc pl-6 space-y-2">
-        <li>15 hours saved each week on document searches</li>
-        <li>Onboarding reduced from three days to thirty minutes</li>
-        <li>$12k per month in consultant fees eliminated</li>
+        <li><strong>15 hours saved per week</strong> on document searches across your team</li>
+        <li><strong>Onboarding time reduced from 3 days to 30 minutes</strong> with instant access to procedures</li>
+        <li><strong>$12,000 monthly savings</strong> in reduced consultant fees and improved efficiency</li>
+        <li><strong>24/7 availability</strong> - your knowledge base never sleeps</li>
       </ul>
 
-      <h2 className="text-2xl font-semibold mt-8">Pricing</h2>
-      <p>Setup is $1,500 with a $1,000 monthly maintenance fee. Most builds take about four hours.</p>
+      <h2 className="text-2xl font-semibold mt-8">Investment & Value</h2>
+      <div className="bg-muted p-6 rounded-lg">
+        <p className="text-lg font-medium">One-time setup: $1,500</p>
+        <p className="text-lg font-medium">Monthly maintenance: $1,000</p>
+        <p className="text-sm text-muted-foreground mt-2">
+          Most implementations are completed within 4 hours. Your system will be operational and saving time immediately.
+        </p>
+      </div>
+      <p className="text-muted-foreground">
+        With typical time savings, most businesses see ROI within the first month of implementation.
+      </p>
 
-      <h2 className="text-2xl font-semibold mt-8">Tech Stack</h2>
-      <ul className="list-disc pl-6 space-y-2">
-        <li>n8n for automation (free tier)</li>
-        <li>OpenAI API for processing (around $30 per month)</li>
-        <li>Supabase for vector storage (free)</li>
-        <li>Google Drive integration</li>
-      </ul>
-      <p className="text-muted-foreground">Total operating cost is under $50 per month.</p>
-
-      <h2 className="text-2xl font-semibold mt-8">How to Get Started</h2>
+      <h2 className="text-2xl font-semibold mt-8">Ready to Transform Your Business?</h2>
       <p>
-        Identify businesses drowning in documents, build a quick proof of concept with sample files, and demonstrate the time savings. Most clients close at $2k or more, and agencies routinely scale this service to significant recurring revenue.
+        Let's discuss how an AI knowledge base can streamline your operations and boost productivity. I'll analyze your current document workflow and show you exactly how much time and money you can save.
       </p>
     </div>
   )

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -5,7 +5,7 @@ const ServicesPage: FC = () => {
     <div className="max-w-3xl mx-auto px-4 py-12 space-y-8">
       <h1 className="text-3xl sm:text-4xl font-bold text-center text-primary">Transform Your Business Documents Into an AI-Powered Knowledge Base</h1>
       <p className="text-muted-foreground text-center text-lg">
-        Stop wasting time searching for information. I build custom AI agents that give your team instant access to your company's knowledge.
+        Stop wasting time searching for information. I build custom AI agents that give your team instant access to your company&apos;s knowledge.
       </p>
 
       <h2 className="text-2xl font-semibold mt-8">The Challenge Your Business Faces</h2>
@@ -44,7 +44,7 @@ const ServicesPage: FC = () => {
 
       <h2 className="text-2xl font-semibold mt-8">Ready to Transform Your Business?</h2>
       <p>
-        Let's discuss how an AI knowledge base can streamline your operations and boost productivity. I'll analyze your current document workflow and show you exactly how much time and money you can save.
+        Let&apos;s discuss how an AI knowledge base can streamline your operations and boost productivity. I&apos;ll analyze your current document workflow and show you exactly how much time and money you can save.
       </p>
     </div>
   )

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -1,0 +1,51 @@
+import { type FC } from 'react'
+
+const ServicesPage: FC = () => {
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-12 space-y-8">
+      <h1 className="text-3xl sm:text-4xl font-bold text-center text-primary">Instant Access to Your Company&#39;s Knowledge</h1>
+      <p className="text-muted-foreground text-center">
+        I build AI agents that turn your business documents into an always-on knowledge base.
+      </p>
+
+      <h2 className="text-2xl font-semibold mt-8">The Problem</h2>
+      <p>
+        Most companies store thousands of files in Google Drive. Employees waste hours searching for information that already exists.
+      </p>
+
+      <h2 className="text-2xl font-semibold mt-8">My Solution</h2>
+      <ul className="list-disc pl-6 space-y-2">
+        <li>Automatically fetches new documents from Google Drive</li>
+        <li>Extracts key data from PDFs, images and more using AI</li>
+        <li>Creates a searchable knowledge base with vector embeddings</li>
+        <li>Deploys a chat agent that answers questions instantly</li>
+      </ul>
+
+      <h2 className="text-2xl font-semibold mt-8">Real Results</h2>
+      <ul className="list-disc pl-6 space-y-2">
+        <li>15 hours saved each week on document searches</li>
+        <li>Onboarding reduced from three days to thirty minutes</li>
+        <li>$12k per month in consultant fees eliminated</li>
+      </ul>
+
+      <h2 className="text-2xl font-semibold mt-8">Pricing</h2>
+      <p>Setup is $1,500 with a $1,000 monthly maintenance fee. Most builds take about four hours.</p>
+
+      <h2 className="text-2xl font-semibold mt-8">Tech Stack</h2>
+      <ul className="list-disc pl-6 space-y-2">
+        <li>n8n for automation (free tier)</li>
+        <li>OpenAI API for processing (around $30 per month)</li>
+        <li>Supabase for vector storage (free)</li>
+        <li>Google Drive integration</li>
+      </ul>
+      <p className="text-muted-foreground">Total operating cost is under $50 per month.</p>
+
+      <h2 className="text-2xl font-semibold mt-8">How to Get Started</h2>
+      <p>
+        Identify businesses drowning in documents, build a quick proof of concept with sample files, and demonstrate the time savings. Most clients close at $2k or more, and agencies routinely scale this service to significant recurring revenue.
+      </p>
+    </div>
+  )
+}
+
+export default ServicesPage


### PR DESCRIPTION
## Summary
- add a dedicated Services page highlighting the AI document-processing solution
- link to the new page from the footer

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_683b8c29edc883259c21e60747310b97