### PR TITLE
Add web app service page and organize services

### DIFF
--- a/app/services/knowledge-base/page.tsx
+++ b/app/services/knowledge-base/page.tsx
@@ -1,0 +1,53 @@
+import { type FC } from 'react'
+
+const ServicesPage: FC = () => {
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-12 space-y-8">
+      <h1 className="text-3xl sm:text-4xl font-bold text-center text-primary">Transform Your Business Documents Into an AI-Powered Knowledge Base</h1>
+      <p className="text-muted-foreground text-center text-lg">
+        Stop wasting time searching for information. I build custom AI agents that give your team instant access to your company&apos;s knowledge.
+      </p>
+
+      <h2 className="text-2xl font-semibold mt-8">The Challenge Your Business Faces</h2>
+      <p>
+        Your company has thousands of valuable documents scattered across Google Drive, SharePoint, and other platforms. Your employees spend hours every week searching for information that already exists, leading to decreased productivity and frustration.
+      </p>
+
+      <h2 className="text-2xl font-semibold mt-8">AI Knowledge Base Solution</h2>
+      <ul className="list-disc pl-6 space-y-2">
+        <li>Automatically connects to your existing document storage systems</li>
+        <li>Uses advanced AI to extract and understand content from PDFs, images, and documents</li>
+        <li>Creates an intelligent, searchable knowledge base</li>
+        <li>Provides a conversational AI assistant that answers questions instantly</li>
+        <li>Updates automatically as you add new documents</li>
+      </ul>
+
+      <h2 className="text-2xl font-semibold mt-8">Proven Business Impact</h2>
+      <ul className="list-disc pl-6 space-y-2">
+        <li><strong>15 hours saved per week</strong> on document searches across your team</li>
+        <li><strong>Onboarding time reduced from 3 days to 30 minutes</strong> with instant access to procedures</li>
+        <li><strong>$12,000 monthly savings</strong> in reduced consultant fees and improved efficiency</li>
+        <li><strong>24/7 availability</strong> - your knowledge base never sleeps</li>
+      </ul>
+
+      <h2 className="text-2xl font-semibold mt-8">Investment & Value</h2>
+      <div className="bg-muted p-6 rounded-lg">
+        <p className="text-lg font-medium">One-time setup: $1,500</p>
+        <p className="text-lg font-medium">Monthly maintenance: $1,000</p>
+        <p className="text-sm text-muted-foreground mt-2">
+          Most implementations are completed within 4 hours. Your system will be operational and saving time immediately.
+        </p>
+      </div>
+      <p className="text-muted-foreground">
+        With typical time savings, most businesses see ROI within the first month of implementation.
+      </p>
+
+      <h2 className="text-2xl font-semibold mt-8">Ready to Transform Your Business?</h2>
+      <p>
+        Let&apos;s discuss how an AI knowledge base can streamline your operations and boost productivity. I&apos;ll analyze your current document workflow and show you exactly how much time and money you can save.
+      </p>
+    </div>
+  )
+}
+
+export default ServicesPage

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -1,53 +1,32 @@
 import { type FC } from 'react'
+import Link from 'next/link'
 
-const ServicesPage: FC = () => {
+const ServicesIndexPage: FC = () => {
   return (
     <div className="max-w-3xl mx-auto px-4 py-12 space-y-8">
-      <h1 className="text-3xl sm:text-4xl font-bold text-center text-primary">Transform Your Business Documents Into an AI-Powered Knowledge Base</h1>
-      <p className="text-muted-foreground text-center text-lg">
-        Stop wasting time searching for information. I build custom AI agents that give your team instant access to your company&apos;s knowledge.
-      </p>
-
-      <h2 className="text-2xl font-semibold mt-8">The Challenge Your Business Faces</h2>
-      <p>
-        Your company has thousands of valuable documents scattered across Google Drive, SharePoint, and other platforms. Your employees spend hours every week searching for information that already exists, leading to decreased productivity and frustration.
-      </p>
-
-      <h2 className="text-2xl font-semibold mt-8">AI Knowledge Base Solution</h2>
-      <ul className="list-disc pl-6 space-y-2">
-        <li>Automatically connects to your existing document storage systems</li>
-        <li>Uses advanced AI to extract and understand content from PDFs, images, and documents</li>
-        <li>Creates an intelligent, searchable knowledge base</li>
-        <li>Provides a conversational AI assistant that answers questions instantly</li>
-        <li>Updates automatically as you add new documents</li>
-      </ul>
-
-      <h2 className="text-2xl font-semibold mt-8">Proven Business Impact</h2>
-      <ul className="list-disc pl-6 space-y-2">
-        <li><strong>15 hours saved per week</strong> on document searches across your team</li>
-        <li><strong>Onboarding time reduced from 3 days to 30 minutes</strong> with instant access to procedures</li>
-        <li><strong>$12,000 monthly savings</strong> in reduced consultant fees and improved efficiency</li>
-        <li><strong>24/7 availability</strong> - your knowledge base never sleeps</li>
-      </ul>
-
-      <h2 className="text-2xl font-semibold mt-8">Investment & Value</h2>
-      <div className="bg-muted p-6 rounded-lg">
-        <p className="text-lg font-medium">One-time setup: $1,500</p>
-        <p className="text-lg font-medium">Monthly maintenance: $1,000</p>
-        <p className="text-sm text-muted-foreground mt-2">
-          Most implementations are completed within 4 hours. Your system will be operational and saving time immediately.
-        </p>
+      <h1 className="text-3xl sm:text-4xl font-bold text-center text-primary">Services</h1>
+      <div className="space-y-10">
+        <div className="space-y-2">
+          <h2 className="text-2xl font-semibold">AI Knowledge Base</h2>
+          <p className="text-muted-foreground">
+            Transform scattered files into an intelligent, searchable resource for your team.
+          </p>
+          <Link href="/services/knowledge-base" className="text-primary underline hover:text-accent">
+            Learn more
+          </Link>
+        </div>
+        <div className="space-y-2">
+          <h2 className="text-2xl font-semibold">Web Application Development</h2>
+          <p className="text-muted-foreground">
+            Custom web-app creation with guided planning and pricing tiers for any size business.
+          </p>
+          <Link href="/services/web-app-development" className="text-primary underline hover:text-accent">
+            Learn more
+          </Link>
+        </div>
       </div>
-      <p className="text-muted-foreground">
-        With typical time savings, most businesses see ROI within the first month of implementation.
-      </p>
-
-      <h2 className="text-2xl font-semibold mt-8">Ready to Transform Your Business?</h2>
-      <p>
-        Let&apos;s discuss how an AI knowledge base can streamline your operations and boost productivity. I&apos;ll analyze your current document workflow and show you exactly how much time and money you can save.
-      </p>
     </div>
   )
 }
 
-export default ServicesPage
+export default ServicesIndexPage

--- a/app/services/web-app-development/page.tsx
+++ b/app/services/web-app-development/page.tsx
@@ -1,0 +1,35 @@
+import { type FC } from 'react'
+import Link from 'next/link'
+
+const WebAppDevelopmentPage: FC = () => {
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-12 space-y-8">
+      <h1 className="text-3xl sm:text-4xl font-bold text-center text-primary">Custom Web Application Development</h1>
+      <p className="text-muted-foreground text-center text-lg">
+        I build tailored web apps that streamline your business processes and delight your users.
+      </p>
+
+      <h2 className="text-2xl font-semibold mt-8">Consultation & Planning</h2>
+      <p>
+        Every project begins with a deep-dive consultation to understand your goals. We schedule calls to map features, choose technologies, and set milestones so you know exactly what to expect.
+      </p>
+
+      <h2 className="text-2xl font-semibold mt-8">Pricing Options</h2>
+      <ul className="list-disc pl-6 space-y-2">
+        <li><strong>Starter</strong> – affordable basics for launching your idea</li>
+        <li><strong>Growth</strong> – expanded features and ongoing support</li>
+        <li><strong>Enterprise</strong> – robust integrations and scale-ready architecture</li>
+      </ul>
+
+      <p className="mt-8 text-center">
+        Ready to build your app?{' '}
+        <Link href="/contact" className="text-primary underline hover:text-accent">
+          Get in touch
+        </Link>
+        .
+      </p>
+    </div>
+  )
+}
+
+export default WebAppDevelopmentPage


### PR DESCRIPTION
## Summary
- move existing AI knowledge base service page into its own folder
- add a new Web Application Development service page
- create a services overview page linking to each service

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_683e01b2b43483259a5a58d865eb71c0