### PR TITLE
Add rotating testimonial carousel

### DIFF
--- a/app/components/Testimonials.tsx
+++ b/app/components/Testimonials.tsx
@@ -1,4 +1,8 @@
-import { type FC } from 'react'
+'use client'
+
+import { type FC, useState, useEffect } from 'react'
+import { AnimatePresence, motion } from 'framer-motion'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
 
 interface Testimonial {
   author: string
@@ -34,18 +38,70 @@ const testimonials: Testimonial[] = [
 ]
 
 export const Testimonials: FC = () => {
+  const [index, setIndex] = useState(0)
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setIndex((prev) => (prev + 1) % testimonials.length)
+    }, 8000)
+    return () => clearInterval(interval)
+  }, [])
+
+  const prev = () =>
+    setIndex((current) =>
+      current === 0 ? testimonials.length - 1 : current - 1,
+    )
+  const next = () =>
+    setIndex((current) => (current + 1) % testimonials.length)
+
   return (
     <section className="space-y-6">
-      <h2 className="text-2xl font-semibold">Testimonials</h2>
-      <div className="space-y-4">
-        {testimonials.map((t) => (
-          <blockquote
-            key={t.author}
-            className="border-l-4 border-accent pl-4 italic"
-          >
-            <p>{t.text}</p>
-            <footer className="mt-2 font-medium not-italic">{t.author}</footer>
-          </blockquote>
+      <h2 className="text-2xl font-semibold text-center">Testimonials</h2>
+      <div className="relative max-w-xl mx-auto">
+        <div className="overflow-hidden">
+          <AnimatePresence mode="wait">
+            <motion.div
+              key={index}
+              initial={{ opacity: 0, x: 50 }}
+              animate={{ opacity: 1, x: 0 }}
+              exit={{ opacity: 0, x: -50 }}
+              transition={{ duration: 0.5 }}
+              className="bg-card border border-border rounded-lg p-6 shadow-sm"
+            >
+              <blockquote className="italic space-y-4 text-center">
+                <p>{testimonials[index].text}</p>
+                <footer className="font-medium not-italic">
+                  {testimonials[index].author}
+                </footer>
+              </blockquote>
+            </motion.div>
+          </AnimatePresence>
+        </div>
+        <button
+          onClick={prev}
+          aria-label="Previous testimonial"
+          className="absolute left-0 top-1/2 -translate-y-1/2 p-2 rounded-full bg-background border border-border text-muted-foreground hover:bg-muted/50"
+        >
+          <ChevronLeft className="w-5 h-5" />
+        </button>
+        <button
+          onClick={next}
+          aria-label="Next testimonial"
+          className="absolute right-0 top-1/2 -translate-y-1/2 p-2 rounded-full bg-background border border-border text-muted-foreground hover:bg-muted/50"
+        >
+          <ChevronRight className="w-5 h-5" />
+        </button>
+      </div>
+      <div className="flex justify-center gap-2">
+        {testimonials.map((_, i) => (
+          <button
+            key={i}
+            onClick={() => setIndex(i)}
+            className={`w-2.5 h-2.5 rounded-full transition-colors duration-200 ${
+              i === index ? 'bg-primary' : 'bg-muted-foreground/30'
+            }`}
+            aria-label={`Show testimonial ${i + 1}`}
+          />
         ))}
       </div>
     </section>


### PR DESCRIPTION
## Summary
- wrap testimonials in card layout with animation
- use a framer-motion carousel that rotates automatically
- navigation arrows and dots allow manual selection

## Testing
- `npm run lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_683f69156ce48325bf3abec27463a4dc