### PR TITLE
Add bid accuracy article

### DIFF
--- a/app/articles/improving-bid-accuracy-and-turnaround/page.tsx
+++ b/app/articles/improving-bid-accuracy-and-turnaround/page.tsx
@@ -1,0 +1,12 @@
+export default function BidAccuracyArticle() {
+  return (
+    <article className="max-w-3xl mx-auto px-4 py-12 space-y-6">
+      <h1 className="text-3xl sm:text-4xl font-bold text-primary">Improving Bid Accuracy and Turnaround</h1>
+      <p>Preparing accurate construction bids involves digging through historical data, past project estimates, and fluctuating material costs. This process is time-consuming and error-prone.</p>
+      <h2 className="text-2xl font-semibold">Problem Example</h2>
+      <p>Estimators often work long hours to gather past job data, vendor quotes, and scope details to build competitive bids under tight deadlines. Errors or omissions frequently lead to profit margin issues or rework.</p>
+      <h2 className="text-2xl font-semibold">AI Solution Engineering</h2>
+      <p>An AI system was implemented to analyze historical bids, cost databases, and project specs to generate draft estimates automatically. The tool flagged scope gaps, suggested line items based on similar past jobs, and pulled in current material pricing from supplier APIs. As a result, bid preparation time was cut in half and margin accuracy increased, helping teams win more competitive contracts with greater confidence.</p>
+    </article>
+  )
+}

--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -12,6 +12,12 @@ const articles = [
     slug: 'enhancing-customer-interaction-and-support',
     description:
       'Design AI agents to draft empathetic responses and standardize communication.'
+  },
+  {
+    title: 'Improving Bid Accuracy and Turnaround',
+    slug: 'improving-bid-accuracy-and-turnaround',
+    description:
+      'Analyze historical bids and materials pricing with AI to produce fast, accurate estimates.'
   }
 ]
 


### PR DESCRIPTION
## Summary
- add article about improving bid accuracy and turnaround
- list the new article on the articles index page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_683f8be572f883258ffbe777717bbca7