### PR TITLE
Add new articles on proposal writing and survey feedback

### DIFF
--- a/app/articles/accelerating-proposal-and-grant-writing/page.tsx
+++ b/app/articles/accelerating-proposal-and-grant-writing/page.tsx
@@ -1,0 +1,12 @@
+export default function ProposalGrantWritingArticle() {
+  return (
+    <article className="max-w-3xl mx-auto px-4 py-12 space-y-6">
+      <h1 className="text-3xl sm:text-4xl font-bold text-primary">Accelerating Proposal and Grant Writing</h1>
+      <p>Crafting proposals, especially for grants or RFPs, can be slow and stressful due to research, formatting, and aligning with specific requirements.</p>
+      <h2 className="text-2xl font-semibold">Problem Example</h2>
+      <p>Teams spend weeks rewriting bios, budgets, and impact statements across different applications—often duplicating work with slight variations for each submission.</p>
+      <h2 className="text-2xl font-semibold">AI Solution Engineering</h2>
+      <p>An AI co-pilot trained on past successful proposals and the current opportunity’s guidelines can auto-generate drafts, tailor content to requirements, and highlight gaps. It can also flag potential compliance issues or recommend phrasing tweaks to boost persuasiveness. This setup might use a mix of custom LLM fine-tuning, semantic search over previous submissions, and templates for consistent formatting.</p>
+    </article>
+  )
+}

--- a/app/articles/making-sense-of-company-wide-survey-feedback/page.tsx
+++ b/app/articles/making-sense-of-company-wide-survey-feedback/page.tsx
@@ -1,0 +1,12 @@
+export default function SurveyFeedbackArticle() {
+  return (
+    <article className="max-w-3xl mx-auto px-4 py-12 space-y-6">
+      <h1 className="text-3xl sm:text-4xl font-bold text-primary">Making Sense of Company-Wide Survey Feedback</h1>
+      <p>Organizations collect feedback through surveys but rarely act on it quickly due to the volume and lack of clarity.</p>
+      <h2 className="text-2xl font-semibold">Problem Example</h2>
+      <p>A quarterly employee survey generates 1,000+ open-text responses. HR knows there are insights buried in the data—but manually reading and categorizing comments is time-consuming.</p>
+      <h2 className="text-2xl font-semibold">AI Solution Engineering</h2>
+      <p>A summarization and clustering pipeline can be built to ingest raw feedback, detect sentiment, categorize themes (e.g., compensation, culture, management), and auto-generate a report with data visualizations and quotes. You can use embeddings for grouping similar comments and plug into BI tools like Looker or Power BI for the output.</p>
+    </article>
+  )
+}

--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -18,6 +18,18 @@ const articles = [
     slug: 'improving-bid-accuracy-and-turnaround',
     description:
       'Analyze historical bids and materials pricing with AI to produce fast, accurate estimates.'
+  },
+  {
+    title: 'Accelerating Proposal and Grant Writing',
+    slug: 'accelerating-proposal-and-grant-writing',
+    description:
+      'Use AI to draft proposals quickly, tailor content, and flag compliance issues.'
+  },
+  {
+    title: 'Making Sense of Company-Wide Survey Feedback',
+    slug: 'making-sense-of-company-wide-survey-feedback',
+    description:
+      'Summarize survey responses and generate reports with sentiment and themes.'
   }
 ]
 


### PR DESCRIPTION
## Summary
- create article about accelerating proposal and grant writing
- create article about making sense of company-wide survey feedback
- list both articles on the articles index page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_683f9469ee888325850a93aafe3ad03b