### PR TITLE
Add AI music video automation article

### DIFF
--- a/app/articles/automating-ai-music-video-publishing/page.tsx
+++ b/app/articles/automating-ai-music-video-publishing/page.tsx
@@ -1,0 +1,54 @@
+export default function AutomatingAIMusicVideoPublishingArticle() {
+  return (
+    <article className="max-w-3xl mx-auto px-4 py-12 space-y-6">
+      <h1 className="text-3xl sm:text-4xl font-bold text-primary">Automating AI Music Video Publishing to Save Time and Effort</h1>
+      <h2 className="text-2xl font-semibold text-primary">The Problem</h2>
+      <p>
+        Publishing AI-generated music videos on YouTube can easily consume hours per song. Manually combining audio with cover art, rendering the video, uploading to YouTube, formatting metadata, and scheduling releases turns into a full-day task when handling large volumes of content.
+      </p>
+      <p>
+        This workflow eliminates that overhead by automating the entire pipeline. What once took a day now happens in minutes, producing consistent, high-quality videos on an intelligent schedule.
+      </p>
+
+      <h2 className="text-2xl font-semibold text-primary">How the Workflow Works</h2>
+      <p>
+        The process starts with audio tracks from Suno and separately sourced cover art uploaded to Google Drive. Their presence triggers the workflow which proceeds through several stages:
+      </p>
+      <h3 className="text-xl font-semibold">Input Stage</h3>
+      <p>
+        Audio and image files placed in Google Drive kick off the automation.
+      </p>
+      <h3 className="text-xl font-semibold">File Handling and Upsert</h3>
+      <p>
+        The workflow performs intelligent upsert operations on Drive to update files without creating duplicates.
+      </p>
+      <h3 className="text-xl font-semibold">Media Processing</h3>
+      <p>
+        A FastAPI service combines the audio and image using FFmpeg, validating that the result is a proper video asset ready for YouTube.
+      </p>
+      <h3 className="text-xl font-semibold">YouTube Scheduling and Metadata Preparation</h3>
+      <p>
+        The workflow reads scheduled posts from a Google Sheet and calculates the next available slot at the brand&apos;s preferred time—3:33&nbsp;PM Hawaii Standard Time. Metadata like the title and tags are cleaned and validated to avoid API errors.
+      </p>
+      <h3 className="text-xl font-semibold">Publishing</h3>
+      <p>
+        Finally, the validated video is uploaded to YouTube with the prepared metadata and scheduled publish date, and the Google Sheet is updated.
+      </p>
+
+      <h2 className="text-2xl font-semibold text-primary">Key Features</h2>
+      <ul className="list-disc list-inside space-y-2">
+        <li>End-to-end automation from raw audio and cover art to scheduled YouTube video</li>
+        <li>Smart file upsert handling in Google Drive</li>
+        <li>FastAPI-powered video generation with full validation</li>
+        <li>Timezone-aware publish date calculation</li>
+        <li>Automatic metadata preparation to ensure API compliance</li>
+        <li>Google Sheets integration for transparent tracking</li>
+      </ul>
+
+      <h2 className="text-2xl font-semibold text-primary">The Result</h2>
+      <p>
+        This workflow creates a reliable AI music video publishing pipeline. What used to be a full day of manual effort per video now takes minutes, letting creators focus on producing content while maintaining a consistent release schedule.
+      </p>
+    </article>
+  )
+}

--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -24,6 +24,12 @@ const articles = [
     slug: 'ai-customer-support-for-supabase-integration',
     description:
       'Automated email replies and feature logging for the Supabase Integration Unity asset.'
+  },
+  {
+    title: 'Automating AI Music Video Publishing to Save Time and Effort',
+    slug: 'automating-ai-music-video-publishing',
+    description:
+      'Automate the entire pipeline from audio and cover art to scheduled YouTube videos.'
   }
 ]
 


### PR DESCRIPTION
## Summary
- add article about automating AI music video publishing
- list the article on the articles page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_684694aec640832583b85156ebf3e043