### PR TITLE
Update company contact email to danejw@yourindie.dev

### DIFF
--- a/app/api/scope-chat-summary/route.ts
+++ b/app/api/scope-chat-summary/route.ts
@@ -579,7 +579,7 @@ ${conversationText}
     // console.log('EMAIL METADATA:');
     // console.log({
     //   from: 'Scope Chat <onboarding@resend.dev>',
-    //   to: ['yourindie101@gmail.com'],
+    //   to: ['danejw@yourindie.dev'],
     //   replyTo: userEmail || undefined,
     //   subject: 'New Scope Chat Summary',
     // });
@@ -648,7 +648,7 @@ ${conversationText}
         html: emailHtml,
         text: emailText,
         subject: 'New Scope Chat Summary',
-        to: 'yourindie101@gmail.com',
+        to: 'danejw@yourindie.dev',
         replyTo: userEmail || undefined,
       },
     });

--- a/app/api/send-email/route.ts
+++ b/app/api/send-email/route.ts
@@ -59,7 +59,7 @@ export async function POST(request: NextRequest) {
       },
       body: JSON.stringify({
         from: 'Contact Form <onboarding@resend.dev>', // Update this with your verified domain in production
-        to: ['yourindie101@gmail.com'],
+        to: ['danejw@yourindie.dev'],
         replyTo: email, // Allow replying directly to the sender
         subject: `New Contact Form Submission from ${sanitizedName}`,
         html: `

--- a/app/articles/ai-customer-support-for-supabase-integration/page.tsx
+++ b/app/articles/ai-customer-support-for-supabase-integration/page.tsx
@@ -16,7 +16,7 @@ export default function AICustomerSupportArticle() {
       
       <h3 className="text-xl font-semibold">1. Email Processing Pipeline</h3>
       <p>
-        The system monitors Gmail every minute using automated triggers, immediately processing new emails related to the Supabase Integration asset. AI classification determines email relevance, filtering out spam and unrelated messages while ensuring only legitimate customer inquiries from external users (excluding yourindie101@gmail.com) receive automated responses.
+        The system monitors Gmail every minute using automated triggers, immediately processing new emails related to the Supabase Integration asset. AI classification determines email relevance, filtering out spam and unrelated messages while ensuring only legitimate customer inquiries from external users (excluding danejw@yourindie.dev) receive automated responses.
       </p>
 
       <h3 className="text-xl font-semibold">2. Knowledge Base (RAG System)</h3>

--- a/app/components/ScopeChat.tsx
+++ b/app/components/ScopeChat.tsx
@@ -404,7 +404,7 @@ export function ScopeChat({ questionAnswers }: ScopeChatProps = {}) {
       console.log('📧 EMAIL METADATA:');
       console.log('='.repeat(80));
       console.log('Subject:', data.emailContent?.subject || 'New Scope Chat Summary');
-      console.log('To:', data.emailContent?.to || 'yourindie101@gmail.com');
+      console.log('To:', data.emailContent?.to || 'danejw@yourindie.dev');
       if (data.emailContent?.replyTo) {
         console.log('Reply To:', data.emailContent.replyTo);
       }

--- a/llm.txt
+++ b/llm.txt
@@ -5,7 +5,7 @@
 ## Documentation Overview
 
 - Portfolio Site: https://yourindie.dev (or current domain)
-- Contact: yourindie101@gmail.com
+- Contact: danejw@yourindie.dev
 - Location: Based in Hawai'i — available remotely
 
 ## Services
@@ -99,6 +99,6 @@ Available for:
 
 ## Contact
 
-- Email: yourindie101@gmail.com
+- Email: danejw@yourindie.dev
 - Location: Based in Hawai'i — available remotely
 - Reach out via email or through any project site above.


### PR DESCRIPTION
### Motivation
- Standardize the public and internal recipient contact address by replacing the legacy Gmail address with the canonical company address `danejw@yourindie.dev` across the site and API code.

### Description
- Replaced occurrences of `yourindie101@gmail.com` / `YourIndie101@gmail.com` with `danejw@yourindie.dev` in documentation and code.
- Updated the contact form recipient in `app/api/send-email/route.ts` to send to `danejw@yourindie.dev`.
- Updated the scope chat summary return payload and commented email metadata in `app/api/scope-chat-summary/route.ts` to reference `danejw@yourindie.dev`.
- Updated console fallback logging in `app/components/ScopeChat.tsx` and article copy in `app/articles/ai-customer-support-for-supabase-integration/page.tsx` to reference the new address.
- Updated documentation file `llm.txt` contact entries.

### Testing
- Searched for occurrences with `rg -n "YourIndie101@gmail\.com|yourindie101@gmail\.com"` and performed a scripted replacement; the script printed modified files `llm.txt`, `app/components/ScopeChat.tsx`, `app/articles/ai-customer-support-for-supabase-integration/page.tsx`, `app/api/scope-chat-summary/route.ts`, and `app/api/send-email/route.ts`, confirming replacements succeeded.
- Verified remaining email literals with `rg -n "[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}"` to ensure the new address appears where expected.
- Ran `npm run lint`, which failed due to pre-existing unrelated lint errors in other components and not caused by these email-only changes; the email update did not introduce new lint issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a1097e8008333b4002fe4778b1bd2)