### PR TITLE
Add Construction OS article

### DIFF
--- a/content/articles/why-we-built-construction-os/article.md
+++ b/content/articles/why-we-built-construction-os/article.md
@@ -1,0 +1,248 @@
+# Why We Built Construction OS
+
+**Project:** Construction OS  
+**Case study type:** Product architecture  
+**What we learned:** Construction AI becomes trustworthy when project evidence, relationships, repeatable skills, configurable context, and document templates work together.  
+**Last updated:** July 18, 2026
+
+## Turning Project Documents Into a Working Project Brain
+
+Construction companies do not usually suffer from a lack of information.
+
+A single project can produce hundreds of pages of drawings, specifications, addenda, estimates, emails, contracts, schedules, proposals, and field reports. The information exists. The real problem is that it is scattered across documents created at different times, by different people, for different purposes.
+
+A project manager may know that a plumbing requirement changed in an addendum. An estimator may remember seeing a detail on a mechanical sheet. A superintendent may understand how a certain assembly is normally built. But that knowledge rarely exists in one place, in a form that the entire company can reliably use.
+
+Most construction software stores documents.
+
+We wanted Construction OS to understand them.
+
+That distinction became the foundation for what we call the **Project Brain**.
+
+The Project Brain is not simply a folder of uploaded files with a chatbot placed on top. It is a structured knowledge system that can read project sources, retrieve relevant information, understand relationships between pieces of information, apply specialized estimating skills, and generate usable project artifacts from what it finds.
+
+The larger goal is straightforward:
+
+**Give the system a project scope, then allow it to reason through the project information and help produce an estimate, proposal, scope sheet, clarification request, or other construction artifact.**
+
+The difficult part is making that process trustworthy.
+
+## The Original Problem
+
+Construction estimating is often treated as a spreadsheet problem.
+
+At the surface, that appears reasonable. An estimate contains quantities, labor rates, material costs, equipment costs, subcontractor quotes, overhead, and margin. All of these eventually become numbers in rows and columns.
+
+But the spreadsheet is rarely where the real estimating work happens. The real work happens before the numbers are entered.
+
+Someone has to determine what is included in the scope. They have to find the relevant drawings, read the specifications, recognize exclusions, identify missing details, understand which trades are affected, compare related sheets, account for alternates, and notice when one document contradicts another.
+
+An estimator is constantly converting unstructured information into structured judgment. That process depends heavily on experience and memory.
+
+A senior estimator may know where information is normally hidden. They know that a general note can affect twenty rooms, that a detail referenced from one sheet may appear somewhere else entirely, or that a particular specification section changes the labor assumption used in the estimate. A newer estimator may read the same documents and miss those connections.
+
+This creates several problems at once. Estimating quality becomes dependent on the individual performing the work. Valuable knowledge stays inside someone’s head. Previous project experience is difficult to reuse. Project documents have to be repeatedly reread. When a scope changes, teams struggle to determine what else the change affects.
+
+The business owns the files, but the individuals still own most of the understanding.
+
+That is the gap Construction OS is intended to close.
+
+## Documents Are Not Knowledge
+
+Uploading every project file into one place does not automatically create intelligence.
+
+A drawing set stored in the cloud is still only a drawing set. A specification PDF remains difficult to search. A folder containing ten previous estimates does not explain why certain assumptions were made.
+
+Even a basic AI document chat system only solves part of the problem.
+
+A conventional retrieval system can split documents into pieces, convert those pieces into embeddings, and locate passages that appear semantically similar to a question. This is useful. It allows someone to ask, “What are the flooring requirements?” and retrieve sections that mention flooring.
+
+But construction information is deeply relational.
+
+A room belongs to a floor. A fixture appears in a room. A detail explains an assembly. A note modifies a drawing. A specification governs a material. A scope item belongs to a trade. An addendum changes a requirement that may already appear in several other places.
+
+Similarity alone does not fully represent those relationships.
+
+We therefore needed the Project Brain to use two complementary forms of memory. The first is a vector-based memory that helps find information by meaning. The second is a knowledge graph that represents how the information connects.
+
+The vector system helps answer: “What information is relevant to this question?” The graph helps answer: “How is this information related to the rest of the project?”
+
+Together, they create a stronger foundation than either system could provide on its own.
+
+## Building the Project Brain
+
+The Project Brain begins when project sources are added to Construction OS.
+
+These sources can include specifications, contracts, bid invitations, schedules, drawings, previous estimates, correspondence, addenda, or other project files. Each source is processed so that its contents can be searched and connected back to the original document.
+
+The system breaks the information into usable sections and generates embeddings that represent their meaning. These embeddings allow the Project Brain to retrieve information even when the user’s wording does not exactly match the source.
+
+For example, a user might ask about “temporary worker housing,” while the project documents refer to “lodging,” “crew accommodations,” or “subsistence.” Semantic retrieval helps the system recognize that these ideas may be related.
+
+Every retrieved section also retains its provenance. The system should know where the information came from, which document contained it, and ideally which page or section supports the answer. Without provenance, an AI response may sound convincing while being impossible to verify.
+
+That is unacceptable in estimating. An estimate is built from assumptions, and assumptions must be traceable.
+
+The next layer is the project knowledge graph. As information is extracted, Construction OS can identify entities such as trades, rooms, drawing sheets, scope items, fixtures, dimensions, materials, callouts, specifications, requirements, and project phases.
+
+The system then connects these entities. A room may connect to its fixtures. A fixture may connect to a plumbing scope item. The scope item may connect to a specification section. The specification may connect to a material requirement. A drawing callout may connect the room to a detail on another sheet.
+
+This changes the Project Brain from a searchable archive into a model of the project. It does not merely remember that two passages contain similar words. It begins to understand that the passages describe different parts of the same construction condition.
+
+## Why We Added a Separate Drawing Extraction Process
+
+Architectural drawings create a special problem.
+
+A specification document is primarily text. A drawing is a dense visual system containing text, geometry, symbols, dimensions, schedules, notes, references, and spatial relationships.
+
+A floor plan cannot be understood correctly by reading its OCR text in isolation. The location of a note matters. The room boundary matters. The symbol beside the note matters. The sheet reference matters. A dimension only makes sense when connected to the objects it measures.
+
+For this reason, we designed architectural drawing extraction as a separate process rather than forcing drawings through the same pipeline used for ordinary documents.
+
+A user can identify which PDFs are actual drawing sets. Construction OS can then process those sources using a drawing-specific extraction workflow.
+
+The system first identifies sheet types such as floor plans, reflected ceiling plans, elevations, details, schedules, mechanical plans, electrical plans, and plumbing plans. It then extracts important information from each sheet, including sheet numbers, titles, room names, dimensions, annotations, symbols, schedules, callouts, references, and visible scope conditions.
+
+The extracted information is saved as structured project data, embedded for semantic retrieval, and connected to the same knowledge graph used by the rest of the Project Brain.
+
+The goal is not to reconstruct a perfect CAD or BIM model from a PDF. The goal is to preserve as much useful construction intelligence as possible and make it available to the estimating and project workflows.
+
+## A Brain Still Needs Abilities
+
+Once the Project Brain could store and retrieve project knowledge, another problem became clear.
+
+Knowledge alone does not define what the system should do with it.
+
+A project may contain everything required to prepare a plumbing scope, but the system still needs a repeatable method for analyzing that information. It needs to know what to search for, which questions to ask, how to organize the findings, what assumptions to surface, and what output to produce.
+
+This is where **skills** enter the system.
+
+A skill is a defined method of work. It tells Construction OS how to perform a particular task using the information available inside the Project Brain.
+
+An estimating skill might instruct the system to identify the relevant trade, retrieve all related scope information, locate specifications and drawing references, identify inclusions and exclusions, detect missing information, form estimating assumptions, and organize the result into a consistent structure.
+
+A proposal-writing skill would behave differently. It might take an approved estimate, project qualifications, exclusions, schedule assumptions, and company information, then convert them into client-facing proposal language. A scope-review skill might compare the drawings, specifications, addenda, and bid documents to find conflicts or omissions.
+
+The AI model supplies general reasoning ability. The skill gives that reasoning a job, a method, and a boundary.
+
+We did not want Construction OS to depend on a single giant prompt that attempted to understand every possible construction task. That would be difficult to maintain, difficult to test, and difficult to improve. Instead, we separated the system into focused capabilities.
+
+The Project Brain contains the project knowledge. Skills define how work should be performed. Tools give the system access to specific functions. Collections provide reusable groups of information. Templates define the structure of the final output. The chat interface coordinates them.
+
+## Using Collections to Make the System Flexible
+
+Construction companies do not all perform the same kind of work.
+
+A general contractor, mechanical contractor, civil contractor, consultant, and specialty subcontractor may each use the same project documents differently. Even within one company, the information required for a commercial tenant improvement is different from the information required for a highway project or residential development.
+
+We introduced **collections** to avoid hard-coding every business rule into the application.
+
+A collection is a reusable body of structured information that can be selected and applied to a workflow.
+
+For example, a construction opportunity collection may contain the NAICS codes the company wants to monitor. A trade collection may contain common scope categories for plumbing, electrical, carpentry, and mechanical work. A labor collection may contain standard crew assumptions, production rates, or estimating rules.
+
+Collections give Construction OS configurable context. Instead of assuming that every company searches for the same opportunities or estimates work using the same categories, the system can pull from the collections relevant to that user, project, or task.
+
+This makes the architecture more general without making the workflow more complicated. The system remains opinionated about how information should be organized, but flexible about which information is used.
+
+## Templates Turn Reasoning Into Deliverables
+
+The output of an estimating process cannot remain trapped inside a chat response.
+
+Construction work depends on artifacts. An estimator needs a scope sheet. A client needs a proposal. A project manager needs a clarification log. An executive may need a bid summary. A superintendent may need a field plan.
+
+These outputs must be consistent, reviewable, and reusable.
+
+Construction OS uses artifact templates to convert structured project reasoning into finished documents.
+
+A template defines the layout and expected content of an artifact. It may include company branding, section order, tables, totals, assumptions, exclusions, signature areas, or other required elements.
+
+The estimating skill determines what information belongs in the result. The artifact template determines how that result is presented.
+
+This separation allows us to improve the reasoning without redesigning the document each time. It also allows the same structured estimate to be rendered into different formats for different audiences.
+
+An internal estimating worksheet may include detailed assumptions and confidence warnings. A client proposal may present only the approved scope, pricing, exclusions, and schedule. The underlying project knowledge can remain the same while the artifact changes.
+
+## How a Scope Becomes an Estimate
+
+Consider a user asking Construction OS to estimate the plumbing scope for a commercial tenant improvement.
+
+The system begins by understanding the request in the context of the current project. It searches the Project Brain for plumbing-related information across the specifications, drawings, schedules, addenda, project notes, and previous artifacts.
+
+It may retrieve fixture schedules, plumbing plans, demolition notes, equipment requirements, floor plan annotations, specification sections, and scope descriptions from the bid documents.
+
+The knowledge graph helps connect the retrieved information. A fixture listed in a schedule may connect to a room shown on the floor plan. That room may connect to a demolition note. The fixture may also require a vent, waste connection, water supply, and coordination with another trade.
+
+The selected estimating skill then evaluates the information. It separates demolition from new work. It identifies fixtures and equipment. It notes connections, supports, testing, permits, coordination requirements, and temporary conditions. It looks for exclusions and inconsistencies. It identifies questions that cannot be answered from the source documents.
+
+Next, the system can apply estimating context from collections. This may include labor assumptions, production rates, travel conditions, crew structures, cost categories, or standard estimating rules.
+
+The result is not immediately treated as a final price.
+
+Construction OS produces a structured estimate with traceable scope, assumptions, quantities where available, missing information, risks, and supporting sources. The estimator reviews and adjusts the result.
+
+Once approved, the estimate can be passed into an artifact template and rendered as a trade estimate, bid summary, proposal, or another required deliverable.
+
+This is the workflow we were trying to create:
+
+**Project sources become project knowledge. Project knowledge is processed through a skill. The skill produces structured information. The structured information is rendered through a template into a usable artifact.**
+
+## The Role of the Human Estimator
+
+The objective is not to remove the estimator. The objective is to give the estimator better leverage.
+
+Construction estimating involves judgment under uncertainty. Documents are incomplete. Scope boundaries are disputed. Production rates depend on conditions that may not be visible in the drawings. Local experience matters. Relationships with subcontractors matter. Risk tolerance matters.
+
+An AI system should not hide that uncertainty behind a confident answer. Construction OS is designed to surface it.
+
+The system should show what it found, where it found it, what it inferred, what remains unknown, and which assumptions influenced the estimate. The estimator remains responsible for deciding whether those assumptions are reasonable.
+
+This creates a more productive division of labor. The system performs the repetitive work of searching, organizing, connecting, and drafting. The estimator applies experience, validates the conclusions, adjusts the assumptions, and approves the result.
+
+The machine becomes a form of structured organizational memory. The human remains the source of accountability and judgment.
+
+## What Actually Made the System Work
+
+The major breakthrough was not adding a more powerful language model. It was separating the responsibilities of the system.
+
+Early AI applications often place nearly everything inside a prompt. The prompt is expected to understand the project, retrieve the correct files, follow company procedures, calculate the estimate, format the result, and produce the final document. That works until the workflow becomes complex.
+
+Construction OS became more reliable when we treated it as an operating system rather than a chatbot.
+
+The Project Brain manages knowledge. Retrieval finds relevant evidence. The graph represents relationships. Skills define repeatable work. Collections provide configurable context. Tools expose controlled actions. Artifact templates create consistent deliverables. The chat interface becomes the place where the user directs the system, but it is no longer the entire system.
+
+This architecture also makes improvement easier. When estimating logic is weak, we can improve the estimating skill. When retrieval is poor, we can improve chunking, embeddings, extraction, or graph relationships. When a document looks wrong, we can improve the artifact template. When the company changes its estimating assumptions, we can update a collection.
+
+Each layer can evolve without forcing us to rebuild everything else.
+
+## From Project Memory to Company Intelligence
+
+The long-term value of the Project Brain extends beyond a single estimate.
+
+Every completed project contains lessons. The original scope can be compared with the final scope. The estimate can be compared with actual labor and material costs. Assumptions can be compared with field conditions. Change orders can reveal information that was missed during bidding. Award data can show which competitors won similar projects and at what price.
+
+Over time, Construction OS can use this information to improve future decisions. The system can identify which assumptions repeatedly prove inaccurate. It can compare similar projects. It can detect scope categories that frequently lead to change orders. It can preserve the reasoning behind successful estimates rather than storing only the final spreadsheet.
+
+This is how a Project Brain can eventually contribute to a larger company brain.
+
+The company begins to retain more of what it learns. A lesson from one project can become context for the next project. A strong estimating method can become a reusable skill. A successful proposal can become a template. A reliable production assumption can become part of a collection.
+
+Instead of knowledge disappearing when a project ends or an employee leaves, the system gives that knowledge a durable structure.
+
+## The Larger Idea
+
+Construction has spent decades digitizing its documents. The next step is to digitize the reasoning that connects them.
+
+That does not mean reducing experience to a set of formulas. It means creating systems that allow experience to be recorded, reused, tested, and improved.
+
+Construction OS began with a practical problem: project information was difficult to retrieve and even harder to turn into consistent work.
+
+The Project Brain gave us a way to organize the knowledge. Skills gave the system methods. Collections gave it flexibility. Templates gave the reasoning a usable form.
+
+Together, these components allow Construction OS to move beyond answering questions about project documents. They allow it to participate in the actual workflow of understanding scope, developing estimates, finding risk, and producing construction deliverables.
+
+The result is not an artificial estimator operating alone. It is an estimating system that helps a human see more, remember more, and work through complex project information with greater consistency.
+
+That is the problem we are solving.
+
+And it is also the reason we built Construction OS in the first place.


### PR DESCRIPTION
### Motivation

- Add a detailed case-study article describing the Construction OS architecture and the Project Brain so it appears alongside the other site articles. 

### Description

- Add new Markdown article at `content/articles/why-we-built-construction-os/article.md` with metadata (`Project`, `Case study type`, `What we learned`, `Last updated`) and the full writeup about vector retrieval, knowledge graphs, drawing extraction, skills, collections, templates, and the human estimator role. 
- Commit the new file and include it in the site's article content so it will be picked up by the existing article loader and sitemap generation. 

### Testing

- Ran `curl` against the local dev server route and received an HTTP `200` with the new page saved to `/tmp/construction-os.html`, confirming the article route renders in development. 
- Ran `git diff --check` which returned clean for this change. 
- Ran `npm run lint` which reported pre-existing lint errors and warnings in unrelated files (these issues are not caused by the new Markdown article).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5bc8d7c5a883339e20e98abfc571df)